### PR TITLE
chore: consumer deployment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "resources/charts/secrets"]
+	path = resources/charts/secrets
+	url = git@code.siemens.com:scxi/edc_secrets.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "resources/charts/secrets"]
-	path = resources/charts/secrets
+[submodule "resources/charts/configs"]
+	path = resources/charts/configs
 	url = git@code.siemens.com:scxi/edc_secrets.git
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
-[submodule "resources/charts/configs"]
-	path = resources/charts/configs
+[submodule "resources/charts/dataspace-connector/configs"]
+	path = resources/charts/dataspace-connector/configs
 	url = git@code.siemens.com:scxi/edc_secrets.git
-	branch = main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ in the detailed section referring to by linking pull requests or issues.
 * JWT audience claim check with DID (#1520)
 * Bump `failsafe` library to version 3.2.4 (#1559)
 * Harmonize logics of `HttpDataSource` and `HttpDataSink` (#1475)
+* Helm Chart
 
 #### Removed
 

--- a/resources/charts/dataspace-connector/templates/secret-config.yaml
+++ b/resources/charts/dataspace-connector/templates/secret-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "dataspace-connector.fullname" . }}-config
+  labels:
+    {{- include "dataspace-connector.labels" . | nindent 4 }}
+type: Opaque
+data:
+{{- $path := printf "configs/%s/*" .Values.edc.connectorType }}
+{{ (.Files.Glob $path).AsSecrets | indent 2 }}

--- a/samples/other/file-transfer-http-to-http/consumer/build.gradle.kts
+++ b/samples/other/file-transfer-http-to-http/consumer/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 }
 
 application {
-    mainClass.set("org.eclipse.dataspaceconnector.boot.system.runtime.BaseRuntime")
+    mainClass.set("com.siemens.mindsphere.ConsumerBaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {


### PR DESCRIPTION
## What this PR changes/adds

Allows for config files to be injected as secrets into Kubernetes pods

## Why it does that

To dynamically change configuration and not be required to bake it in the Docker Image

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
